### PR TITLE
Add photo sorting Streamlit app (group by EXIF capture date)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+pillow

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,91 @@
+import datetime as dt
+import io
+import zipfile
+
+from PIL import Image, ExifTags
 import streamlit as st
 
-st.title("🎈 My new app")
+DATE_FORMAT = "%d-%m-%Y"
+NO_DATE_FOLDER = "Sans_date"
+
+EXIF_TAGS = {value: key for key, value in ExifTags.TAGS.items()}
+DATE_TAGS = [
+    EXIF_TAGS.get("DateTimeOriginal"),
+    EXIF_TAGS.get("DateTimeDigitized"),
+    EXIF_TAGS.get("DateTime"),
+]
+
+
+def parse_exif_date(image: Image.Image) -> dt.date | None:
+    exif_data = image.getexif()
+    if not exif_data:
+        return None
+
+    for tag in DATE_TAGS:
+        if tag is None:
+            continue
+        raw_value = exif_data.get(tag)
+        if not raw_value:
+            continue
+        try:
+            return dt.datetime.strptime(raw_value, "%Y:%m:%d %H:%M:%S").date()
+        except ValueError:
+            continue
+    return None
+
+
+def build_zip(files: list[tuple[str, bytes]]) -> tuple[bytes, dict[str, int]]:
+    stats: dict[str, int] = {}
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for filename, data in files:
+            file_date = None
+            try:
+                with Image.open(io.BytesIO(data)) as image:
+                    file_date = parse_exif_date(image)
+            except OSError:
+                file_date = None
+
+            if file_date:
+                folder_name = file_date.strftime(DATE_FORMAT)
+            else:
+                folder_name = NO_DATE_FOLDER
+
+            stats[folder_name] = stats.get(folder_name, 0) + 1
+            archive_path = f"{folder_name}/{filename}"
+            archive.writestr(archive_path, data)
+
+    return buffer.getvalue(), stats
+
+
+st.set_page_config(page_title="Tri de photos", page_icon="📸")
+
+st.title("📸 Tri automatique de photos")
 st.write(
-    "Let's start building! For help and inspiration, head over to [docs.streamlit.io](https://docs.streamlit.io/)."
+    "Chargez vos photos et récupérez une archive ZIP avec des dossiers par date de prise. "
+    "Le format utilisé est **jour-mois-année** (ex. 27-03-2024)."
 )
+
+uploaded_files = st.file_uploader(
+    "Ajoutez des photos (JPEG, PNG, HEIC si pris en charge)",
+    type=["jpg", "jpeg", "png", "heic"],
+    accept_multiple_files=True,
+)
+
+if uploaded_files:
+    st.info("Nous analysons les métadonnées EXIF pour déterminer la date de prise.")
+    files_payload = [(file.name, file.getvalue()) for file in uploaded_files]
+    zip_bytes, zip_stats = build_zip(files_payload)
+
+    st.subheader("Résumé")
+    for folder, count in sorted(zip_stats.items()):
+        st.write(f"- **{folder}** : {count} photo(s)")
+
+    st.download_button(
+        "Télécharger l'archive ZIP",
+        data=zip_bytes,
+        file_name="photos_triees.zip",
+        mime="application/zip",
+    )
+else:
+    st.warning("Ajoutez des photos pour lancer le tri.")


### PR DESCRIPTION
### Motivation
- Provide a simple UI to sort uploaded photos into folders named by capture date (day-month-year) using EXIF metadata.
- Produce a downloadable ZIP archive structured with per-date directories to ease photo organisation.
- Gracefully handle images without EXIF date by placing them into a `Sans_date` folder.

### Description
- Replace the starter Streamlit app with a photo sorter implemented in `streamlit_app.py` that groups uploads by EXIF capture date.
- Add `pillow` to `requirements.txt` to enable image and EXIF parsing.
- Add `parse_exif_date` to extract EXIF date tags and `build_zip` to assemble a ZIP with folders named using `DATE_FORMAT` or `Sans_date`.
- Add UI elements: `st.file_uploader` for multiple files, a summary view, and a `st.download_button` to download the generated ZIP.

### Testing
- Launched the app with `streamlit run streamlit_app.py` and the server started successfully.
- Captured an automated UI screenshot using Playwright which completed and produced an artifact.
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac91287d0832d9f2992a847b9da67)